### PR TITLE
Add libssl-dev to build and run depends

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>mongodb-dev</build_depend>
   <build_depend>curl</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rostime</run_depend>
@@ -27,6 +28,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>mongodb-dev</run_depend>
   <run_depend>curl</run_depend>
+  <run_depend>libssl-dev</run_depend>
   
   <test_depend>gtest</test_depend>
 


### PR DESCRIPTION
OpenSSL is used at CMakeLists.txt#L11 and is in rosdistro at https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L1643
