### PR TITLE
generate headers in devel space instead of build space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ find_package(catkin REQUIRED
 find_package(Boost COMPONENTS system filesystem thread)
 find_package(OpenSSL)
 
-file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+file(MAKE_DIRECTORY "${CATKIN_DEVEL_PREFIX}/include")
 
 catkin_package(
-  INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/include include
+  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include
   LIBRARIES warehouse_ros
   CATKIN_DEPENDS roscpp geometry_msgs rostime std_msgs
   DEPENDS Boost
@@ -24,9 +24,9 @@ include(cmake/FindMongoDB.cmake)
 if (NOT MongoDB_EXPOSE_MACROS)
   add_definitions(-DMONGO_EXPOSE_MACROS)
 endif()
-configure_file("include/mongo_ros/config.h.in" "include/mongo_ros/config.h")
+configure_file("include/mongo_ros/config.h.in" "${CATKIN_DEVEL_PREFIX}/include/mongo_ros/config.h")
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include include ${catkin_INCLUDE_DIRS} ${MongoDB_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+include_directories(${CATKIN_DEVEL_PREFIX}/include include ${catkin_INCLUDE_DIRS} ${MongoDB_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 link_directories(${catkin_LINK_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
@@ -43,4 +43,4 @@ target_link_libraries(test_mongo_roscpp warehouse_ros)
 install(TARGETS warehouse_ros LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
 install(PROGRAMS src/mongo_wrapper_ros.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/mongo_ros/config.h" DESTINATION include/mongo_ros)
+install(FILES "${CATKIN_DEVEL_PREFIX}/include/mongo_ros/config.h" DESTINATION include/mongo_ros)


### PR DESCRIPTION
With the upcoming catkin version passing absolute INCLUDE_DIRS to catkin_package() will be allowed (ros/catkin#600). But since your absolute _build_ space path is temporary downstream packages will fail to find that folder. (Before any absolute path was ignored but there where use cases where it should be possible.)

Instead this pull request generates the header in the _devel_ space which catkin is aware of and assumes that these generated files will be installed by the user (similar as generated message headers).

Please review and test - I haven't even tried to compile the package after the change :wink: This fix should be released in _Groovy_, _Hydro_ and _Indigo_.
