### PR TITLE
Export libmongoclient library to dependent modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(warehouse_ros)
 
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
+
 find_package(catkin REQUIRED
   geometry_msgs
   roscpp
@@ -9,6 +11,7 @@ find_package(catkin REQUIRED
   std_msgs)
 find_package(Boost COMPONENTS system filesystem thread)
 find_package(OpenSSL)
+find_package(MongoDB)
 
 file(MAKE_DIRECTORY "${CATKIN_DEVEL_PREFIX}/include")
 
@@ -16,10 +19,9 @@ catkin_package(
   INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include
   LIBRARIES warehouse_ros
   CATKIN_DEPENDS roscpp geometry_msgs rostime std_msgs
-  DEPENDS Boost
+  DEPENDS Boost MongoDB
   )
 
-include(cmake/FindMongoDB.cmake)
 
 if (NOT MongoDB_EXPOSE_MACROS)
   add_definitions(-DMONGO_EXPOSE_MACROS)


### PR DESCRIPTION
This change fixes the build of dependent modules with libmongoclient.so

Ubuntu/Debian's package of mongodb is pretty much non-standard.
E.g. for some reason they decided to provide libmongoclient only as a static library.
Granted, there were problems with building the shared object in the past,
but it worked perfectly fine for the last year or so and different distributions
use it (Arch, Lunar-Linux, etc...).

Because the warehouse_ros headers include mongo/\* headers,
functions provided by the client library can be (and indirectly are) used
by ros-modules which depend on warehouse_ros.

As long as warehouse_ros links the static libmongoclient library everything
is fine, because the mongodb functions used in dependent projects
now are provided by libwarehouse_ros.so.

However, this is no longer the case when the shared client library is used.
In this case dependent modules use functions which are provided by libmongoclient.so
but don't link to them because warehouse_ros doesn't specify the lib-dependency.

catkin_package's DEPENDS makes all local MongoDB_\* variables directly available
to dependent modules via find_package(warehouse_ros) as part of the warehouse_ros_\* variables.
Therefore those modules don't have to find_package MongoDB on their own.
