### PR TITLE
only export MongoDB dependency for shared mongodb-library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,18 @@ find_package(Boost COMPONENTS system filesystem thread)
 find_package(OpenSSL)
 find_package(MongoDB)
 
+set(MONGO_EXPORT)
+if("${MongoDB_LIBRARIES}" MATCHES "\\.so$")
+  set(MONGO_EXPORT MongoDB)
+endif()
+
 file(MAKE_DIRECTORY "${CATKIN_DEVEL_PREFIX}/include")
 
 catkin_package(
   INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include
   LIBRARIES warehouse_ros
   CATKIN_DEPENDS roscpp geometry_msgs rostime std_msgs
-  DEPENDS Boost MongoDB
+  DEPENDS Boost ${MONGO_EXPORT}
   )
 
 


### PR DESCRIPTION
libmongoclient.a uses quite a number of other libs and the exact requirements
can't be read from a cmake/pc file. Therefore it makes more sense to keep the
dependency hidden from ROS when we use the static lib. libwarehouse_ros then
provides all required functions.
... This is a bit like creating a libmongoclient.so, but the whole problem 
exists because debian/ubuntu don't provide this one, right?

The shared library can - and has to - be exported as a dependency to ROS.

This pull-request should cleanup the problem @tfoote noticed in #14.

Please have a look @isucan.
