### PR TITLE
Ensure headers and libraries are present for downstream pkgs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
   <run_depend>rostime</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>mongodb</run_depend>
+  <run_depend>mongodb-dev</run_depend>
   <run_depend>python-pymongo</run_depend>
   <run_depend>curl</run_depend>
   <run_depend>libssl-dev</run_depend>


### PR DESCRIPTION
Downstream packages need the headers and, in some cases, need the .so libraries present. The debian buildfarm defaults to static libraries because `BUILD_SHARED_LIBS` is not set, so this does not affect any packages there.

Example breaks:
- https://csc.mcs.sdsmt.edu/jenkins/job/ros-hydro-map-store_binaryrpm_heisenbug_x86_64/28/console
- https://csc.mcs.sdsmt.edu/jenkins/job/ros-hydro-moveit-ros-warehouse_binaryrpm_heisenbug_x86_64/36/console
- https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-moveit-ros-warehouse_binaryrpm_heisenbug_x86_64/50/console

Thanks,

--scott
