### PR TITLE
Enable tests for Jade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,26 @@
-# Generic MoveIt Travis Continuous Integration Configuration File
-# Works with all MoveIt! repositories/branches
-# Author: Dave Coleman, Jonathan Bohren
-language:
-  - cpp
-  - python
-python:
-  - "2.7"
+sudo: required 
+dist: trusty 
+language: generic 
 compiler:
   - gcc
 notifications:
   email:
+    on_success: always
+    on_failure: always
     recipients:
-      - dave.hershberger@sri.com
-    on_success: change #[always|never|change] # default: change
-    on_failure: change #[always|never|change] # default: always
-before_install: # Use this to prepare the system to install prerequisites or dependencies
-  # Define some config vars
-  - export ROS_DISTRO=hydro
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
-  # MongoDB hack - I don't fully understand this but its for moveit_warehouse
-  - sudo apt-get remove -y mongodb mongodb-10gen
-  - sudo apt-get install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" # default actions
-  # Setup rosdep
-  - sudo rosdep init
-  - rosdep update
-install: # Use this to install any prerequisites or dependencies necessary to run your build
-  # Create workspace
-  - mkdir -p ~/ros/ws_moveit/src
-  - cd ~/ros/ws_moveit/src
-  - wstool init .
-  # Download non-debian stuff
-  - wstool merge https://raw.github.com/ros-planning/moveit_docs/hydro-devel/moveit.rosinstall
-  - wstool update
-  # Delete the moveit.rosinstall version of this repo and use the one of the branch we are testing
-  - rm -rf $REPOSITORY_NAME
-  - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-  - cd ../
-  # Install dependencies for source repos
-  - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
-before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - source /opt/ros/$ROS_DISTRO/setup.bash  
-script: # All commands must exit with code 0 on success. Anything else is considered failure.
-  - catkin_make -j2
+      - gm130s@gmail.com
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+matrix:
+  allow_failures:
+    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - source .ci_config/travis.sh  # mongo hack (https://github.com/ros-planning/warehouse_ros/blob/849d5979e0186db124d3a1eda0278ebaa15e4ff0/.travis.yml#L27-L29) is already taken care of in here.
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 endif()
-find_package(Boost COMPONENTS system filesystem)
+find_package(Boost REQUIRED COMPONENTS system)
 find_package(OpenSSL)
 find_package(MongoDB)
 
@@ -26,7 +26,7 @@ catkin_python_setup()
 
 catkin_package(
   INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include test
-  LIBRARIES warehouse_ros
+#  LIBRARIES warehouse_ros
   CATKIN_DEPENDS roscpp geometry_msgs rostime std_msgs
   DEPENDS Boost ${MONGO_EXPORT}
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 endif()
-find_package(Boost COMPONENTS system filesystem thread)
+find_package(Boost COMPONENTS system filesystem)
 find_package(OpenSSL)
 find_package(MongoDB)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(warehouse_ros)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
 
-find_package(catkin REQUIRED
+find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   roscpp
   rostime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ file(MAKE_DIRECTORY "${CATKIN_DEVEL_PREFIX}/include")
 catkin_python_setup()
 
 catkin_package(
-  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include
+  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include include test
   LIBRARIES warehouse_ros
   CATKIN_DEPENDS roscpp geometry_msgs rostime std_msgs
   DEPENDS Boost ${MONGO_EXPORT}
@@ -37,7 +37,7 @@ if (NOT MongoDB_EXPOSE_MACROS)
 endif()
 configure_file("include/mongo_ros/config.h.in" "${CATKIN_DEVEL_PREFIX}/include/mongo_ros/config.h")
 
-include_directories(${CATKIN_DEVEL_PREFIX}/include include ${catkin_INCLUDE_DIRS} ${MongoDB_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+include_directories(${CATKIN_DEVEL_PREFIX}/include include test ${catkin_INCLUDE_DIRS} ${MongoDB_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 link_directories(${catkin_LINK_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,11 @@ set(warehouse_srcs
   src/mongo_ros_dummy.cpp)
 
 add_library(warehouse_ros SHARED ${warehouse_srcs})
-
 target_link_libraries(warehouse_ros ${catkin_LIBRARIES} ${MongoDB_LIBRARIES} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES})
-catkin_add_gtest(test_mongo_roscpp test/test_mongo_ros.cpp)
-target_link_libraries(test_mongo_roscpp warehouse_ros ${catkin_LIBRARIES})
+
 if (CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_mongo_roscpp test/test_mongo_ros.cpp)
+  target_link_libraries(test_mongo_roscpp warehouse_ros)
   add_rostest(test/mongo_ros.test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,11 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
 find_package(catkin REQUIRED
   geometry_msgs
   roscpp
-  rostest
   rostime
   std_msgs)
+if (CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest)
+endif()
 find_package(Boost COMPONENTS system filesystem thread)
 find_package(OpenSSL)
 find_package(MongoDB)
@@ -47,7 +49,10 @@ add_library(warehouse_ros SHARED ${warehouse_srcs})
 
 target_link_libraries(warehouse_ros ${catkin_LIBRARIES} ${MongoDB_LIBRARIES} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES})
 catkin_add_gtest(test_mongo_roscpp test/test_mongo_ros.cpp)
-target_link_libraries(test_mongo_roscpp warehouse_ros)
+target_link_libraries(test_mongo_roscpp warehouse_ros ${catkin_LIBRARIES})
+if (CATKIN_ENABLE_TESTING)
+  add_rostest(test/mongo_ros.test)
+endif()
 
 install(TARGETS warehouse_ros LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   rostime
   std_msgs)
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rostest)
+  find_package(rostest REQUIRED)
 endif()
 find_package(Boost COMPONENTS system filesystem thread)
 find_package(OpenSSL)
@@ -49,8 +49,9 @@ add_library(warehouse_ros SHARED ${warehouse_srcs})
 target_link_libraries(warehouse_ros ${catkin_LIBRARIES} ${MongoDB_LIBRARIES} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES})
 
 if (CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(test_mongo_roscpp test/test_mongo_ros.cpp)
-  target_link_libraries(test_mongo_roscpp warehouse_ros)
+#  catkin_add_gtest(test_mongo_roscpp test/test_mongo_ros.cpp)
+  add_executable(test_mongo_roscpp test/test_mongo_ros.cpp)
+  target_link_libraries(test_mongo_roscpp ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${MongoDB_LIBRARIES})
   add_rostest(test/mongo_ros.test)
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>rospy</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rostime</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rospy</build_depend>
+  <test_depend>rosunit</test_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rostime</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <test_depend>rosunit</test_depend>
-
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rostime</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -22,6 +23,7 @@
   <build_depend>curl</build_depend>
   <build_depend>libssl-dev</build_depend>
 
+  <run_depend>boost</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rostime</run_depend>
   <run_depend>geometry_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rostime</build_depend>
-  <build_depend>rostest</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>mongodb-dev</build_depend>
   <build_depend>python-pymongo</build_depend>
@@ -33,5 +32,6 @@
   <run_depend>libssl-dev</run_depend>
   
   <test_depend>gtest</test_depend>
+  <test_depend>rostest</test_depend>
 
 </package>

--- a/test/mongo_ros.test
+++ b/test/mongo_ros.test
@@ -1,0 +1,4 @@
+<launch> 
+  <test test-name="test_mongo_roscpp" pkg="warehouse_ros" type="test_mongo_roscpp" name="test_mongo_roscpp" />
+  <test test-name="test_mongo_rospy" pkg="warehouse_ros" type="test_mongo_rospy.py" name="test_mongo_rospy" />
+</launch>


### PR DESCRIPTION
To address an existing issue like https://github.com/ros-planning/warehouse_ros/pull/22#issuecomment-179368708

As noted in-file already, [mongo hack is already implemented in the depended script](https://github.com/ros-industrial/industrial_ci/blob/9d08a556e873a6481076ead6534a996ff06050fa/travis.sh#L97-L102).