### PR TITLE
append cmake module path instead of prepending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(warehouse_ros)
 
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
 find_package(catkin REQUIRED COMPONENTS
   geometry_msgs


### PR DESCRIPTION
Prepending is non-standard and breaks external overlays as in
https://github.com/ros-planning/geometric_shapes/issues/22
