### PR TITLE
update include statements to use new pluginlib and class_loader headers

### DIFF
--- a/include/warehouse_ros/database_loader.h
+++ b/include/warehouse_ros/database_loader.h
@@ -39,7 +39,7 @@
 
 #include <boost/scoped_ptr.hpp>
 #include <warehouse_ros/database_connection.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 namespace warehouse_ros
 {

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <build_depend>rostime</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>pluginlib</build_depend>
+  <build_depend version_gte="1.11.2">pluginlib</build_depend>
   <build_depend>tf</build_depend>
 
   <run_depend>boost</run_depend>
@@ -25,7 +25,7 @@
   <run_depend>rostime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <run_depend version_gte="1.11.2">pluginlib</run_depend>
   <run_depend>tf</run_depend>
   
   <test_depend>gtest</test_depend>


### PR DESCRIPTION
Disclaimer: This in an automated PR, if it is not relevant on this branch, apologies for the inconveniance, feel free close it.

----

`pluginlib` and `class_loader` headers have been refactored and renamed. The previous headers `.h` have been deprecated in favor of their `.hpp` equivalent. The new headers are available on all active ROS distributions and the deprecated ones will be removed in a future version of ROS (likely ROS-N).

This PR migrates the include statements to use the non-deprecated ones and should compile for any active ROS distribution starting with Indigo
The migration was done by running the scripts [pluginlib_headers_migration.py](https://github.com/ros/pluginlib/blob/6ada92c4665a392339c683682de1d1503658c209/scripts/pluginlib_headers_migration.py) and [class_loader_headers_update.py](https://github.com/ros/class_loader/blob/1515546103de4d987daa8f5519ca43fe6cffbca6/scripts/class_loader_headers_update.py) on this repository.
Note: this will not work for Jade