### PR TITLE
Remove user-defined constructors

### DIFF
--- a/include/warehouse_ros/impl/message_collection_impl.hpp
+++ b/include/warehouse_ros/impl/message_collection_impl.hpp
@@ -50,25 +50,6 @@ MessageCollection<M>::MessageCollection(MessageCollectionHelper::Ptr collection)
 }
 
 template <class M>
-MessageCollection<M>::MessageCollection(const MessageCollection<M>& other)
-  : collection_(other.collection_), md5sum_matches_(other.md5sum_matches_)
-{
-}
-
-template <class M>
-MessageCollection<M>::~MessageCollection()
-{
-}
-
-template <class M>
-MessageCollection<M>& MessageCollection<M>::operator=(const MessageCollection& other)
-{
-  collection_ = other.collection_;
-  md5sum_matches_ = other.md5sum_matches_;
-  return *this;
-}
-
-template <class M>
 void MessageCollection<M>::insert(const M& msg, Metadata::Ptr metadata)
 {
   if (!md5sum_matches_)

--- a/include/warehouse_ros/impl/query_results_impl.hpp
+++ b/include/warehouse_ros/impl/query_results_impl.hpp
@@ -48,30 +48,6 @@ ResultIterator<M>::ResultIterator(ResultIteratorHelper::Ptr results, bool metada
 }
 
 template <class M>
-ResultIterator<M>::ResultIterator(const ResultIterator<M>& other)
-  : results_(other.results_), metadata_only_(other.metadata_only_)
-{
-}
-
-template <class M>
-ResultIterator<M>::ResultIterator() : metadata_only_(false)
-{
-}
-
-template <class M>
-ResultIterator<M>::~ResultIterator()
-{
-}
-
-template <class M>
-ResultIterator<M>& ResultIterator<M>::operator=(const ResultIterator& other)
-{
-  results_ = other.results_;
-  metadata_only_ = other.metadata_only_;
-  return *this;
-}
-
-template <class M>
 void ResultIterator<M>::increment()
 {
   if (!results_->next())

--- a/include/warehouse_ros/message_collection.h
+++ b/include/warehouse_ros/message_collection.h
@@ -72,13 +72,8 @@ public:
   /// created if it doesn't exist.
   MessageCollection(MessageCollectionHelper::Ptr collection);
 
-  /// \brief Copy constructor
-  MessageCollection(const MessageCollection& rhs);
-
-  /// \brief Destructor
-  ~MessageCollection();
-
-  MessageCollection& operator=(const MessageCollection& other);
+  /// \brief Default constructor
+  MessageCollection() = default;
 
   /// \brief Insert a ROS message, together with some optional metadata,
   /// into the db
@@ -130,7 +125,7 @@ public:
 
 private:
   MessageCollectionHelper::Ptr collection_;
-  bool md5sum_matches_;
+  bool md5sum_matches_ = false;
 };
 
 }  // namespace warehouse_ros

--- a/include/warehouse_ros/query_results.h
+++ b/include/warehouse_ros/query_results.h
@@ -66,16 +66,8 @@ public:
   /// \brief Constructor
   ResultIterator(ResultIteratorHelper::Ptr results, bool metadata_only);
 
-  /// \brief Copy constructor
-  ResultIterator(const ResultIterator& rhs);
-
-  /// \brief Constructor for past_the_end iterator
-  ResultIterator();
-
-  /// \brief Destructor
-  ~ResultIterator();
-
-  ResultIterator& operator=(const ResultIterator& other);
+  /// \brief Default constructor
+  ResultIterator() = default;
 
 private:
   friend class boost::iterator_core_access;
@@ -86,7 +78,7 @@ private:
   bool equal(const ResultIterator<M>& other) const;
 
   ResultIteratorHelper::Ptr results_;
-  const bool metadata_only_;
+  bool metadata_only_ = false;
 };
 
 template <class M>


### PR DESCRIPTION
Stick a bit more to the rule of zero.
`ResultIterator::metadata_only_` is now non-const to allow (move) assignments.
Based on #50 