### PR TITLE
Fix ccache directory and upload test artifacts

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -13,7 +13,8 @@ jobs:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
     env:
-      CCACHE_DIR: ~/.ccache
+      CCACHE_DIR: /home/runner/.ccache
+      BASEDIR: .base
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,3 +26,8 @@ jobs:
             ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-results
+          path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml


### PR DESCRIPTION
See this PR where I tested the various ways of specifying the ccache directory until I got it working: https://github.com/ros-planning/warehouse_ros/pull/64

Here is a reference to the issue where I got the idea for uploading the artifacts: https://github.com/ros-industrial/industrial_ci/issues/644