### PR TITLE
Add python black formatter to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']
 
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+
   - repo: local
     hooks:
       - id: misspelled-moveit


### PR DESCRIPTION
I know there are no python files in this repo, however I'd like to add this as the formatter we use by default in all our repos.  Black is similar to clang-format in that it will automatically reformat your python code.  This is nice for many of the same reasons that clang-format is nice for c++.