### PR TITLE
List OpenSSL as build depend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
-find_package(OpenSSL)
+find_package(OpenSSL REQUIRED)
 
 include_directories(
   include

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>boost</build_depend>
+  <build_depend>libssl-dev</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -33,7 +34,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This is a dependency and it should be listed in the package.xml and should be required in the find_package call.