### PR TITLE
Fix building on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(warehouse_srcs
   src/transform_collection.cpp)
 
 add_library(warehouse_ros SHARED ${warehouse_srcs})
+set_target_properties(warehouse_ros PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 ament_target_dependencies(warehouse_ros
   rclcpp
   std_msgs


### PR DESCRIPTION
Setting the `WINDOWS_EXPORT_ALL_SYMBOLS` property exports the symbols by default to match the behavior of GCC. This fixes the missing symbol issues when building `warehouse_test_dbloader`