### PR TITLE
Use ament_export_targets to fix exporting dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ ament_target_dependencies(warehouse_test_dbloader
 target_link_libraries(warehouse_test_dbloader warehouse_ros ${OPENSSL_CRYPTO_LIBRARY})
 
 ament_export_include_directories(include)
-ament_export_libraries(warehouse_ros)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(std_msgs)
 ament_export_dependencies(geometry_msgs)
@@ -70,6 +70,7 @@ ament_export_dependencies(OpenSSL)
 
 install(
   TARGETS warehouse_ros
+  EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ ament_target_dependencies(warehouse_ros
   Boost
 )
 target_link_libraries(warehouse_ros ${OPENSSL_CRYPTO_LIBRARY})
+target_include_directories(warehouse_ros
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PUBLIC $<INSTALL_INTERFACE:include>
+)
 
 add_executable(warehouse_test_dbloader src/test_dbloader.cpp)
 ament_target_dependencies(warehouse_test_dbloader
@@ -56,7 +60,6 @@ ament_target_dependencies(warehouse_test_dbloader
 )
 target_link_libraries(warehouse_test_dbloader warehouse_ros ${OPENSSL_CRYPTO_LIBRARY})
 
-ament_export_include_directories(include)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(std_msgs)


### PR DESCRIPTION
Otherwise, the dependencies will not be exported correctly, this's required for https://github.com/ros-planning/moveit2/pull/514 to pass