### PR TITLE
Fix OpenSSL export

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>tf2_geometry_msgs</build_depend>
 
   <run_depend>boost</run_depend>
+  <run_depend>libssl-dev</run_depend>
   <run_depend>rclcpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,7 @@
-<package>
+<package format="3">
   <name>warehouse_ros</name>
   <version>2.0.2</version>
-  <description>
-    Persistent storage of ROS messages
-  </description>
+  <description>Persistent storage of ROS messages</description>
   <author email="bhaskara@willowgarage.com">Bhaskara Marthi</author>
   <author email="cbrew@fetchrobotics.com">Connor Brew</author>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -13,25 +11,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>boost</build_depend>
-  <build_depend>libssl-dev</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend version_gte="1.11.2">pluginlib</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-
-  <run_depend>boost</run_depend>
-  <run_depend>libssl-dev</run_depend>
-  <run_depend>rclcpp</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend version_gte="1.11.2">pluginlib</run_depend>
-  <run_depend>tf2</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>tf2_geometry_msgs</run_depend>
+  <depend>boost</depend>
+  <depend>libssl-dev</depend>
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>


### PR DESCRIPTION
The package `libssl-dev` is not registered as debian dependency so that the exported `OpenSSL` target is not available when compiling MoveIt (https://github.com/ros-planning/moveit2/runs/2944725655?check_suite_focus=true). This is fixed by adding it as run dependency as well (tested with `bloom-generate rosdebian`).