### PR TITLE
[ROS 2] Release 2.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package warehouse_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.3 (2021-06-29)
+------------------
+* Fix OpenSSL export, use package.xml format 3 (`#83 <https://github.com/ros-planning/warehouse_ros/issues/83>`_)
+* Contributors: Henning Kayser
+
 2.0.2 (2021-06-29)
 ------------------
 * Use ament_export_targets to fix exporting dependencies (`#80 <https://github.com/ros-planning/warehouse_ros/issues/80>`_)

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>warehouse_ros</name>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
   <description>Persistent storage of ROS messages</description>
   <author email="bhaskara@willowgarage.com">Bhaskara Marthi</author>
   <author email="cbrew@fetchrobotics.com">Connor Brew</author>


### PR DESCRIPTION
Confirmed fixing the OpenSSL export issue, compiled MoveIt successfully locally with a pre-release debian.

Pre-release test: https://github.com/ros-planning/warehouse_ros/actions/runs/983949260