### PR TITLE
 updated tf2_geometry_msgs.h to tf2_geometry_msgs.hpp 

### DIFF
--- a/include/warehouse_ros/transform_collection.h
+++ b/include/warehouse_ros/transform_collection.h
@@ -41,11 +41,12 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+// TODO(v4hn): remove after EOL galactic
 #if __has_include(<tf2_geometry_msgs/tf2_geometry_msgs.hpp>)
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#endif```
+#endif
 #include <tf2_ros/buffer.h>
 
 namespace warehouse_ros

--- a/include/warehouse_ros/transform_collection.h
+++ b/include/warehouse_ros/transform_collection.h
@@ -41,7 +41,11 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#if __has_include(<tf2_geometry_msgs/tf2_geometry_msgs.hpp>)
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#endif```
 #include <tf2_ros/buffer.h>
 
 namespace warehouse_ros

--- a/include/warehouse_ros/transform_collection.h
+++ b/include/warehouse_ros/transform_collection.h
@@ -41,7 +41,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 
 namespace warehouse_ros


### PR DESCRIPTION
Warning was presented to change this when building ROS2 Rolling and Moveit2 from source 