### PR TITLE
Fix public OpenSSL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(pluginlib REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system filesystem thread)
+find_package(Boost REQUIRED)
 find_package(OpenSSL REQUIRED)
 
 set(warehouse_srcs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,14 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(OpenSSL REQUIRED)
 
-include_directories(
-  include
-  ${OPENSSL_INCLUDE_DIR}
-)
-
 set(warehouse_srcs
   src/database_loader.cpp
   src/transform_collection.cpp)
 
 add_library(warehouse_ros SHARED ${warehouse_srcs})
+target_link_libraries(warehouse_ros PUBLIC OpenSSL::Crypto)
 set_target_properties(warehouse_ros PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-ament_target_dependencies(warehouse_ros
+ament_target_dependencies(warehouse_ros PUBLIC
   rclcpp
   std_msgs
   geometry_msgs
@@ -41,14 +37,13 @@ ament_target_dependencies(warehouse_ros
   tf2_geometry_msgs
   Boost
 )
-target_link_libraries(warehouse_ros ${OPENSSL_CRYPTO_LIBRARY})
 target_include_directories(warehouse_ros
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PUBLIC $<INSTALL_INTERFACE:include>
 )
 
 add_executable(warehouse_test_dbloader src/test_dbloader.cpp)
-ament_target_dependencies(warehouse_test_dbloader
+ament_target_dependencies(warehouse_test_dbloader PUBLIC
   rclcpp
   std_msgs
   geometry_msgs
@@ -58,7 +53,7 @@ ament_target_dependencies(warehouse_test_dbloader
   tf2_geometry_msgs
   Boost
 )
-target_link_libraries(warehouse_test_dbloader warehouse_ros ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(warehouse_test_dbloader PUBLIC warehouse_ros)
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp)


### PR DESCRIPTION
warehouse_ros is using `MD5()` from OpenSSL in inline code in a header,
so every consumer of the headers have to link against libcrypto.
By using the OpenSSL::Crypto target, ament can do that for us.
Due to the different cases of the OpenSSL module and variable names,
`ament_target_dependencies` does not work with plain old variables.