### PR TITLE
[ros2] Remove Foxy CI, fix ccache

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -40,14 +40,14 @@ jobs:
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
         if: ${{ ! matrix.env.CCOV }}
-        uses: pat-s/always-upload-cache@v2.1.3
+        uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ env.BASEDIR }}/target_ws
           key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: pat-s/always-upload-cache@v2.1.3
+        uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -15,10 +15,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - ROS_DISTRO: foxy
-            ROS_REPO: main
-          - ROS_DISTRO: foxy
-            ROS_REPO: testing
           - ROS_DISTRO: rolling
             ROS_REPO: main
           - ROS_DISTRO: rolling


### PR DESCRIPTION
Our ccache is broken in CI, thus our ccache action should be updated to match Github's new ccache action v2 as per https://github.com/ros-planning/moveit2/pull/619

This PR also removes Foxy CI from the ros2 branch.