### PR TITLE
Update header file (.h to .hpp)

### DIFF
--- a/include/warehouse_ros/transform_collection.h
+++ b/include/warehouse_ros/transform_collection.h
@@ -41,7 +41,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 
 namespace warehouse_ros


### PR DESCRIPTION
SImilar to #85. If that one gets updated soon, let's close this PR.

Fixes this warning:

```
In file included from /home/andy/ws_ros2/src/warehouse_ros/include/warehouse_ros/transform_collection.h:44,
                 from /home/andy/ws_ros2/src/warehouse_ros/src/transform_collection.cpp:37:
/opt/ros/rolling/include/tf2_geometry_msgs/tf2_geometry_msgs.h:35:2: warning: #warning This header is obsolete, please include tf2_geometry_msgs/tf2_geometry_msgs.hpp instead [-Wcpp]
   35 | #warning This header is obsolete, please include tf2_geometry_msgs/tf2_geometry_msgs.hpp instead
```